### PR TITLE
fix: remove lint job from GitHub workflows

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -5,14 +5,6 @@ on:
       - 'master'
 
 jobs:
-  lint:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-go@v3
-        with:
-          go-version: 1.19
-      - uses: golangci/golangci-lint-action@v3
   test:
     runs-on: ubuntu-latest
     needs: lint
@@ -20,7 +12,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v3
         with:
-          go-version: 1.21
+          go-version: 1.21.5
       - run: go test -v ./...
   release:
     runs-on: ubuntu-latest


### PR DESCRIPTION
The lint job has been removed from the GitHub workflows cd.yml file to simplify the jobs run on each commit. Additionally, the Go version has been upgraded from 1.21 to 1.21.5 for optimal compatibility with the latest Go standards and best practices.

# Pull Request

## Checklist

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) guidelines and my PR follows them, also I agree to the [GNU GPLv3](../LICENSE) license.
- [x] I have read the [CODE_OF_CONDUCT](CODE_OF_CONDUCT.md) and the [Developer Certificate of Origin](DCO.md) and I agree to follow them.

## Description

## Related Resources

## Additional Info
