### PR TITLE
fix: remove testing step from CD workflow

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -5,18 +5,8 @@ on:
       - 'master'
 
 jobs:
-  test:
-    runs-on: ubuntu-latest
-    needs: lint
-    steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-go@v3
-        with:
-          go-version: 1.21.5
-      - run: go test -v ./...
   release:
     runs-on: ubuntu-latest
-    needs: test
     permissions:
       contents: write
     steps:


### PR DESCRIPTION
The changes in this commit remove the testing step from the continuous deployment (CD) workflow. This includes removing the corresponding dependencies for this job. Therefore, new releases won't be dependent on passing the testing step.

# Pull Request

## Checklist

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) guidelines and my PR follows them, also I agree to the [GNU GPLv3](../LICENSE) license.
- [x] I have read the [CODE_OF_CONDUCT](CODE_OF_CONDUCT.md) and the [Developer Certificate of Origin](DCO.md) and I agree to follow them.

## Description

## Related Resources

## Additional Info
